### PR TITLE
Removed obsolete properties (slug & count) from mongodb xml-config-fi…

### DIFF
--- a/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -11,7 +11,6 @@
         <field name="slug"          type="string"       fieldName="slug"    />
 
         <field name="description"   type="string"   fieldName="description"    />
-        <field name="count"         type="int"      fieldName="count"          />
 
         <field name="createdAt"    type="timestamp"   fieldName="createdAt" />
         <field name="updatedAt"    type="timestamp"   fieldName="updatedAt" />

--- a/Resources/config/doctrine/BaseContext.mongodb.xml
+++ b/Resources/config/doctrine/BaseContext.mongodb.xml
@@ -7,7 +7,6 @@
     <mapped-superclass name="Sonata\ClassificationBundle\Document\BaseContext">
 
         <field name="enabled"       type="boolean"      fieldName="enabled" />
-        <field name="slug"          type="string"       fieldName="slug"    />
 
         <field name="createdAt"     type="timestamp"    fieldName="createdAt" />
         <field name="updatedAt"     type="timestamp"    fieldName="updatedAt" />


### PR DESCRIPTION
…les.

Fixes Issue #174.

While doing a composer update a RuntimeException will be thrown because the
property $slug could not be found (Thrown ReflectionClassException).
After removing the slug-line in BaseContext.mongodb.xml and doing a composer
update a "Property $count could not be found" message was thrown.
After removing the count-line in BaseCategory.mongodb.xml and doing a
composer update all will be fine.
These lines have to be removed because the accordingly properties didn't
exist anymore in Model\Category.php and Model\Context.php.